### PR TITLE
LITE-12681 Added CQRS_SELECT_FOR_UPDATE to ReplicaMixin

### DIFF
--- a/dj_cqrs/managers.py
+++ b/dj_cqrs/managers.py
@@ -45,7 +45,11 @@ class ReplicaManager(Manager):
             pk_value = mapped_data[pk_name]
             f_kwargs = {pk_name: pk_value}
 
-            instance = self.model._default_manager.filter(**f_kwargs).first()
+            qs = self.model._default_manager.filter(**f_kwargs)
+            if self.model.CQRS_SELECT_FOR_UPDATE:
+                qs = qs.select_for_update()
+
+            instance = qs.first()
 
             if instance:
                 return self.update_instance(

--- a/dj_cqrs/mixins.py
+++ b/dj_cqrs/mixins.py
@@ -273,6 +273,9 @@ class ReplicaMixin(Model, metaclass=ReplicaMeta):
     CQRS_CUSTOM_SERIALIZATION = False
     """Set it to True to skip default data check."""
 
+    CQRS_SELECT_FOR_UPDATE = False
+    """Set it to True to acquire lock on instance creation/update."""
+
     objects = Manager()
 
     cqrs = ReplicaManager()

--- a/tests/dj_replica/models.py
+++ b/tests/dj_replica/models.py
@@ -48,6 +48,13 @@ class BadMappingModelRef(ReplicaMixin, models.Model):
     name = models.CharField(max_length=200)
 
 
+class LockModelRef(ReplicaMixin, models.Model):
+    CQRS_ID = 'lock'
+    CQRS_SELECT_FOR_UPDATE = True
+
+    id = models.IntegerField(primary_key=True)
+
+
 class Event(models.Model):
     pid = models.IntegerField()
     cqrs_id = models.CharField(max_length=20)


### PR DESCRIPTION
This adds support for automatic locking of records for CQRS save operations for replica models with CQRS_SELECT_FOR_UPDATE=True