### PR TITLE
LITE-25465: Fix AMQPConnectorException in RabbitMQTransport.consume

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         pip install -r requirements/dev.txt
         pip install -r requirements/test.txt
         pip install pytest-cov
+        pip install djangorestframework==3.13.*
         pip install django==2.2.*
     - name: Linting
       run: |

--- a/dj_cqrs/admin.py
+++ b/dj_cqrs/admin.py
@@ -14,8 +14,8 @@ class CQRSAdminMasterSyncMixin:
         Overriding method from AdminModel class; it is used to include the sync method in
         the actions list.
         """
-        if self.actions is not None:
-            self.actions = self.actions + ['sync_items']
+        if self.actions is not None and 'sync_items' not in self.actions:
+            self.actions = list(self.actions) + ['sync_items']
         return super().get_actions(request)
 
     def _cqrs_sync_queryset(self, queryset):


### PR DESCRIPTION
- Refactor RabbitMQTransport.produce() retry loop
- Add AMQPConnectorException to list of handled exceptions for retry
- also: fixed issue in CQRSAdminMasterSyncMixin.get_actions(), because newer Django versions changed default actions value from list to tuple