### PR TITLE
Fix Integration tests, they failed silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ Unit testing
 
 Run tests with various RDBMS:
 - `cd integration_tests`
-- `DB=postgres docker-compose -f docker-compose.yml -f rdbms.yml up app_test`
-- `DB=mysql docker-compose -f docker-compose.yml -f rdbms.yml up app_test`
+- `DB=postgres docker-compose -f docker-compose.yml -f rdbms.yml run app_test`
+- `DB=mysql docker-compose -f docker-compose.yml -f rdbms.yml run app_test`
 
 Check code style: `flake8`
 Run tests: `pytest`

--- a/tests/test_replica/test_mixin.py
+++ b/tests/test_replica/test_mixin.py
@@ -546,7 +546,7 @@ def test_get_cqrs_retry_delay(settings, retry_delay, current_retry):
     assert result is retry_delay
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_support_for_meta_create():
     meta = TransportStub.consume(
         TransportPayload(
@@ -565,7 +565,7 @@ def test_support_for_meta_create():
     assert meta == {'Hello': 'world'}
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_support_for_meta_update():
     models.CQRSMetaModel.objects.create(id=2, cqrs_revision=0, cqrs_updated=now())
 
@@ -589,7 +589,7 @@ def test_support_for_meta_update():
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_support_for_meta_delete():
     models.CQRSMetaModel.objects.create(id=3, cqrs_revision=0, cqrs_updated=now())
 

--- a/travis_integration_tests.sh
+++ b/travis_integration_tests.sh
@@ -11,8 +11,8 @@ if [ "$INTEGRATION_TESTS" == "yes" ]; then
     docker-compose down --remove-orphans
     docker-compose -f docker-compose.yml -f kombu.yml run master
 	  docker-compose -f docker-compose.yml -f kombu.yml down --remove-orphans
-	  DB=postgres docker-compose -f docker-compose.yml -f rdbms.yml up app_test
-	  DB=mysql docker-compose -f docker-compose.yml -f rdbms.yml up app_test
+	  DB=postgres docker-compose -f docker-compose.yml -f rdbms.yml run app_test
+	  DB=mysql docker-compose -f docker-compose.yml -f rdbms.yml run app_test
 	  docker-compose -f docker-compose.yml -f rdbms.yml down --remove-orphans
 
     cd ..


### PR DESCRIPTION
- `docker compose up` always returned exit status 0, so pgsql and mysql integration test failing were not detected. Using `docker compose run` fixes this.
- Fixed some tests failing with postgres and mysql: calling `close_old_connections()` when consuming messages while in transaction caused current connection to be closed.