### PR TITLE
LITE-25512: Skip send save message from master model on commit if instance doesn't exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         pip install -r requirements/test.txt
         pip install pytest-cov
         pip install djangorestframework==3.13.*
+        pip install django-model-utils==4.2.0
         pip install django==2.2.*
     - name: Linting
       run: |

--- a/dj_cqrs/mixins.py
+++ b/dj_cqrs/mixins.py
@@ -277,11 +277,8 @@ class RawMasterMixin(Model):
             instance = self
         else:
             db = using if using is not None else self._state.db
-            qs = self.__class__._default_manager.using(db).filter(pk=self.pk)
-
-            instance = self.relate_cqrs_serialization(qs).first()
-            if not instance:
-                raise RuntimeError("Couldn't serialize CQRS class ({0}).".format(self.CQRS_ID))
+            qs = self.__class__._default_manager.using(db)
+            instance = self.relate_cqrs_serialization(qs).get(pk=self.pk)
 
         data = self._cqrs_serializer_cls(instance).data
         data['cqrs_revision'] = instance.cqrs_revision

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -13,7 +13,7 @@ Getting started
 Requirements
 ============
 
-`django-cqrs` works with Python 3.6 or later and has the following dependencies:
+`django-cqrs` works with Python 3.7 or later and has the following dependencies:
 
     * Django >= 2.2
     * pika >= 1.0.0

--- a/tests/test_master/test_mixin.py
+++ b/tests/test_master/test_mixin.py
@@ -511,11 +511,13 @@ def test_to_cqrs_dict_serializer_import_error():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_to_cqrs_dict_serializer_bad_related_function():
-    with pytest.raises(RuntimeError) as e:
-        models.BadQuerySetSerializationClassModel.objects.create()
+def test_to_cqrs_dict_serializer_bad_related_function(caplog):
+    models.BadQuerySetSerializationClassModel.objects.create()
 
-    assert "Couldn't serialize CQRS class (bad_queryset)." in str(e)
+    assert (
+        "Can't produce message from master model 'BadQuerySetSerializationClassModel': "
+        "The instance doesn't exist"
+    ) in caplog.text
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
The exception `"RuntimeError: Couldn't serialize CQRS class"` is raised when the master model instance doesn't exist at the moment of sending the post_save message. If it is in a transaction, the message sending is postponed with `on_commit`, and in some rare case the instance could have been deleted by another process.
Because this situation may happen, don't raise an exception, but log an error if the instance doesn't exist and skip the sending of the message.